### PR TITLE
Adjusting the type of value required for list subscriptions

### DIFF
--- a/src/Endpoints/ListSubscription.php
+++ b/src/Endpoints/ListSubscription.php
@@ -58,7 +58,7 @@ class ListSubscription extends Endpoint
      *                              status returned in the response.
      * @param string $source_id     - Description of where the recipient signed up 
      *                              for this list.
-     * @param bool   $confirmed     - Confirmed = "true" or Unconfirmed = "false"
+     * @param string $confirmed     - Confirmed = "true" or Unconfirmed = "false"
      *
      * @return object The API response object
      */

--- a/src/Endpoints/ListSubscription.php
+++ b/src/Endpoints/ListSubscription.php
@@ -69,9 +69,10 @@ class ListSubscription extends Endpoint
         string $list_status = null,
         string $global_status = null,
         string $source_id = null,
-        bool $confirmed = null 
+        string $confirmed = null 
     ) { 
         Validator::oneOf($status, [ 'NORMAL', 'UNSUB' ]);
+        Validator::oneOf($confirmed, [ 'true', 'false' ], false);
 
         return $this->client->request(
             'POST',


### PR DESCRIPTION
Fixes value type for `$confirmed` in the `subscribe()` function within the `ListSubscription` endpoint. The casting originally forced true on every subscriber. Changing this value to a string is what PostUp expects.