### PR TITLE
Removing requirement for channel status in update recipient endpoint

### DIFF
--- a/src/Endpoints/Recipient.php
+++ b/src/Endpoints/Recipient.php
@@ -158,7 +158,7 @@ Class Recipient extends Endpoint
         array $demographics             = null,
         string $password                = null 
     ) {
-        Validator::oneOf($channel, [ 'E', 'S', 'P' ]);
+        Validator::oneOf($channel, [ 'E', 'S', 'P' ], false);
         Validator::oneOf($status, [ 'N', 'U', 'H' ], false);
         Validator::isDate($third_party_signup_date, false);
 


### PR DESCRIPTION
Fixing an issue where the update recipient endpoint requires a channel to be of a certain type.